### PR TITLE
ci: push releases with a deploy key to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # pushes authenticate with the deploy key, which is on the ruleset
+          # bypass list; humans still have to go through a pull request
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/setup-node@v4
         with:
@@ -100,7 +103,7 @@ jobs:
           git add package.json package-lock.json CHANGELOG.md
 
           git diff --quiet && git diff --staged --quiet || (
-            git commit -m "[ci skip]: release v${new_version}" --no-verify
+            git commit -m "[ci skip]: release ${new_version}" --no-verify
           )
 
           # the annotated tag points at the release commit itself;


### PR DESCRIPTION
The GitHub Actions app cannot be a ruleset bypass actor on personal repos, so the release workflow authenticates its pushes with a write deploy key that is on the protect-main ruleset bypass list. Humans still go through pull requests with required status checks.